### PR TITLE
Add disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a port of the [Typesafe Config](https://github.com/typesafehub/config) l
 The library provides Ruby support for the [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md) configuration file format.
 
 At present, the only features it supports are explicit parsing of config files (.conf/HOCON, .json, .properties) via `ConfigFactory.parse_file`, and rendering a parsed config object back to a String.  Testing is minimal and not all data types are supported yet.  It also does not yet support `include` or interpolated settings.
+PLEASE NOTE that as a result this project is in a very experimental state, and in some cases may not work properly, so
+please be wary when using it. If you find a problem, feel free to open a github issue.
 
 The implementation is intended to be as close to a line-for-line port as the two languages allow, in hopes of making it fairly easy to port over new changesets from the Java code base over time.
 


### PR DESCRIPTION
Add a disclaimer to the README explaining that this library is in
an experimental state and some features may not work properly.

This came out of a suggestion from @aperiodic. I'm doing this as a PR so that @waynr and @cprice404 can take a look and make sure this change looks okay.