### PR TITLE
Fix NameError when parsing {\n}

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hocon (0.0.5)
+    hocon (0.0.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/hocon/impl/parser.rb
+++ b/lib/hocon/impl/parser.rb
@@ -479,7 +479,7 @@ class Hocon::Impl::Parser
                       add_quote_suggestion(t, "Expecting close brace } or a comma, got #{t}",
                                            last_path, last_inside_equals))
           else
-            if t.token == Tokens::END
+            if t.token == Tokens::EOF
               put_back(t)
               break
             else
@@ -568,7 +568,7 @@ class Hocon::Impl::Parser
         result = parse_value(t)
       else
         if @syntax == ConfigSyntax::JSON
-          if t.token == Tokens::END
+          if t.token == Tokens::EOF
             raise parse_error("Empty document")
           else
             raise parse_error("Document must have an object or array at root, unexpected token: #{t}")


### PR DESCRIPTION
Fix a NameError that would occur when a string containing
{\n} was parsed.