### PR TITLE
Allow gem to parse JSON files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hocon (0.0.5)
+    hocon (0.0.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/hocon/impl/parser.rb
+++ b/lib/hocon/impl/parser.rb
@@ -12,6 +12,7 @@ require 'hocon/impl/simple_config_object'
 require 'hocon/impl/config_impl_util'
 require 'hocon/impl/tokenizer'
 require 'hocon/impl/simple_config_origin'
+require 'hocon/impl/path'
 
 class Hocon::Impl::Parser
   
@@ -26,6 +27,7 @@ class Hocon::Impl::Parser
   ConfigImplUtil = Hocon::Impl::ConfigImplUtil
   PathBuilder = Hocon::Impl::PathBuilder
   Tokenizer = Hocon::Impl::Tokenizer
+  Path = Hocon::Impl::Path
   
   class TokenWithComments
     def initialize(token, comments = [])

--- a/lib/hocon/impl/path.rb
+++ b/lib/hocon/impl/path.rb
@@ -131,6 +131,10 @@ class Hocon::Impl::Path
     pb.result
   end
 
+  def self.new_key(key)
+    return self.new(key, nil)
+  end
+
   def self.new_path(path)
     Hocon::Impl::Parser.parse_path(path)
   end

--- a/spec/fixtures/parse_render/example3/input.json
+++ b/spec/fixtures/parse_render/example3/input.json
@@ -1,0 +1,6 @@
+{
+    "kermit": "frog",
+    "miss": "piggy",
+    "bert": "ernie",
+    "janice": "guitar"
+}

--- a/spec/fixtures/parse_render/example3/output.conf
+++ b/spec/fixtures/parse_render/example3/output.conf
@@ -1,0 +1,6 @@
+{
+    "kermit"="frog",
+    "miss"="piggy",
+    "bert"="ernie",
+    "janice"="guitar"
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,11 @@ EXAMPLE2 = { :hash =>
     :name => "example2",
   }
 
+EXAMPLE3 = { :hash =>
+                 {"kermit" => "frog",
+                  "miss" => "piggy",
+                  "bert" => "ernie",
+                  "janice" => "guitar"},
+             :name => "example3",
+}
+

--- a/spec/unit/typesafe/config/config_factory_spec.rb
+++ b/spec/unit/typesafe/config/config_factory_spec.rb
@@ -35,7 +35,7 @@ describe Hocon::ConfigFactory do
   end
 
   shared_examples_for "config_factory_parsing" do
-    let(:input_file)  { "#{FIXTURE_DIR}/parse_render/#{example[:name]}/input.conf" }
+    let(:input_file)  { "#{FIXTURE_DIR}/parse_render/#{example[:name]}/input#{extension}" }
     let(:output_file) { "#{FIXTURE_DIR}/parse_render/#{example[:name]}/output.conf" }
     let(:expected)    { example[:hash] }
     let(:reparsed)    { Hocon::ConfigFactory.parse_file("#{output_file}") }
@@ -60,6 +60,7 @@ describe Hocon::ConfigFactory do
 
   context "example1" do
     let(:example) { EXAMPLE1 }
+    let (:extension) { ".conf" }
 
     context "parsing a HOCON string" do
       let(:string) { File.open(input_file).read }
@@ -75,6 +76,7 @@ describe Hocon::ConfigFactory do
 
   context "example2" do
     let(:example) { EXAMPLE2 }
+    let (:extension) { ".conf" }
 
     context "parsing a HOCON string" do
       let(:string) { File.open(input_file).read }
@@ -89,6 +91,16 @@ describe Hocon::ConfigFactory do
   end
 
   context "example3" do
+    let(:example) { EXAMPLE3 }
+    let (:extension) { ".json" }
+
+    context "parsing a .json file" do
+      let (:conf) { Hocon::ConfigFactory.parse_file(input_file) }
+      include_examples "config_factory_parsing"
+    end
+  end
+
+  context "example4" do
     it "should raise a ConfigParseError when given an invalid .conf file" do
       expect{Hocon::ConfigFactory.parse_string("abcdefg")}.to raise_error(Hocon::ConfigError::ConfigParseError)
     end


### PR DESCRIPTION
Allow the ruby hocon gem to parse JSON files. Previously,
attempting to parse a JSON file would lead to an uninitialized
constant error.