### PR TITLE
(TK-155) Port tokenizer tests to ruby hocon

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hocon (0.0.6)
+    hocon (0.0.7)
 
 GEM
   remote: https://rubygems.org/
@@ -18,6 +18,7 @@ GEM
     rspec-mocks (2.99.2)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/lib/hocon/impl/abstract_config_value.rb
+++ b/lib/hocon/impl/abstract_config_value.rb
@@ -65,6 +65,21 @@ class Hocon::Impl::AbstractConfigValue
     end
   end
 
+  def can_equal(other)
+    other.is_a?(Hocon::Impl::AbstractConfigValue)
+  end
+
+  def ==(other)
+    # note that "origin" is deliberately NOT part of equality
+    if other.is_a?(Hocon::Impl::AbstractConfigValue)
+      can_equal(other) &&
+          value_type == other.value_type &&
+          ConfigImplUtil.equals_handling_nil?(unwrapped, other.unwrapped)
+    else
+      false
+    end
+  end
+
   def to_s
     sb = StringIO.new
     render_to_sb(sb, 0, true, nil, Hocon::ConfigRenderOptions.concise)

--- a/lib/hocon/impl/config_float.rb
+++ b/lib/hocon/impl/config_float.rb
@@ -7,6 +7,10 @@ class Hocon::Impl::ConfigFloat < Hocon::Impl::ConfigNumber
     @value = value
   end
 
+  def value_type
+    Hocon::ConfigValueType::NUMBER
+  end
+
   def unwrapped
     @value
   end

--- a/lib/hocon/impl/config_null.rb
+++ b/lib/hocon/impl/config_null.rb
@@ -3,7 +3,7 @@ require 'hocon/config_value_type'
 
 class Hocon::Impl::ConfigNull < Hocon::Impl::AbstractConfigValue
   def value_type
-    Hocon::Impl::ConfigValueType::NULL
+    Hocon::ConfigValueType::NULL
   end
 
   def unwrapped

--- a/lib/hocon/impl/token.rb
+++ b/lib/hocon/impl/token.rb
@@ -2,6 +2,7 @@ require 'hocon/impl'
 require 'hocon/impl/token_type'
 
 class Hocon::Impl::Token
+  attr_reader :token_type
   def self.new_without_origin(token_type, debug_string)
     Hocon::Impl::Token.new(token_type, nil, debug_string)
   end
@@ -28,5 +29,10 @@ class Hocon::Impl::Token
     else
       Hocon::Impl::TokenType.name(@token_type)
     end
+  end
+
+  def ==(other)
+    # @origin deliberately left out
+    other.is_a?(Hocon::Impl::Token) && @token_type == other.token_type
   end
 end

--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -181,11 +181,11 @@ class Hocon::Impl::Tokens
   end
 
   def self.new_int(origin, value, original_text)
-    new_value(ConfigInt.new(origin, value, original_text))
+    new_value(ConfigNumber.new_number(origin, value, original_text))
   end
 
   def self.new_float(origin, value, original_text)
-    new_value(ConfigFloat.new(origin, value, original_text))
+    new_value(ConfigNumber.new_number(origin, value, original_text))
   end
 
   def self.new_long(origin, value, original_text)

--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -35,6 +35,10 @@ class Hocon::Impl::Tokens
       @text = text
     end
     attr_reader :text
+
+    def ==(other)
+      super(other) && other.text == @text
+    end
   end
 
   # This is not a Value, because it requires special processing
@@ -43,6 +47,12 @@ class Hocon::Impl::Tokens
       super(TokenType::SUBSTITUTION, origin)
       @optional = optional
       @value = expression
+    end
+
+    attr_reader :value
+
+    def ==(other)
+      super(other) && other.value == @value
     end
   end
 
@@ -56,6 +66,10 @@ class Hocon::Impl::Tokens
     def to_s
       "'#{value}'"
     end
+
+    def ==(other)
+      super(other) && other.value == @value
+    end
   end
 
   class Value < Token
@@ -63,16 +77,25 @@ class Hocon::Impl::Tokens
       super(TokenType::VALUE, value.origin)
       @value = value
     end
+
     attr_reader :value
 
     def to_s
       "'#{value.unwrapped}' (#{Hocon::ConfigValueType.name(value.value_type)})"
+    end
+
+    def ==(other)
+      super(other) && other.value == @value
     end
   end
 
   class Line < Token
     def initialize(origin)
       super(TokenType::NEWLINE, origin)
+    end
+
+    def ==(other)
+      super(other) && other.line_number == line_number
     end
   end
 
@@ -99,6 +122,13 @@ class Hocon::Impl::Tokens
 
     def cause
       @cause
+    end
+
+    def ==(other)
+      super(other) && other.what == @what &&
+          other.message == @message &&
+          other.suggest_quotes == @suggest_quotes &&
+          Hocon::Impl::ConfigImplUtil.equals_handling_nil?(other.cause, @cause)
     end
   end
 

--- a/lib/hocon/impl/tokens.rb
+++ b/lib/hocon/impl/tokens.rb
@@ -3,6 +3,7 @@ require 'hocon/impl/token'
 require 'hocon/impl/token_type'
 require 'hocon/impl/config_number'
 require 'hocon/impl/config_string'
+require 'hocon/impl/config_null'
 require 'hocon/impl/config_boolean'
 require 'hocon/config_error'
 
@@ -11,7 +12,10 @@ class Hocon::Impl::Tokens
   Token = Hocon::Impl::Token
   TokenType = Hocon::Impl::TokenType
   ConfigNumber = Hocon::Impl::ConfigNumber
+  ConfigInt = Hocon::Impl::ConfigInt
+  ConfigFloat = Hocon::Impl::ConfigFloat
   ConfigString = Hocon::Impl::ConfigString
+  ConfigNull = Hocon::Impl::ConfigNull
   ConfigBoolean = Hocon::Impl::ConfigBoolean
 
   START = Token.new_without_origin(TokenType::START, "start of file")
@@ -146,12 +150,28 @@ class Hocon::Impl::Tokens
     new_value(ConfigString.new(origin, value))
   end
 
+  def self.new_int(origin, value, original_text)
+    new_value(ConfigInt.new(origin, value, original_text))
+  end
+
+  def self.new_float(origin, value, original_text)
+    new_value(ConfigFloat.new(origin, value, original_text))
+  end
+
   def self.new_long(origin, value, original_text)
     new_value(ConfigNumber.new_number(origin, value, original_text))
   end
 
+  def self.new_null(origin)
+    new_value(ConfigNull.new(origin))
+  end
+
   def self.new_boolean(origin, value)
     new_value(ConfigBoolean.new(origin, value))
+  end
+
+  def self.new_substitution(origin, optional, expression)
+    Substitution.new(origin, optional, expression)
   end
 
   def self.comment?(t)

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -9,12 +9,16 @@ module TestUtils
     [Tokens::START] + token_list + [Tokens::EOF]
   end
 
-  def TestUtils.tokenize_as_list(input_string)
+  def TestUtils.tokenize(input_string)
     origin = Hocon::Impl::SimpleConfigOrigin.new_simple("test")
     options = Hocon::ConfigParseOptions.defaults
     io = StringIO.open(input_string)
 
-    token_iterator =  Hocon::Impl::Tokenizer.tokenize(origin, io, options)
+    Hocon::Impl::Tokenizer.tokenize(origin, io, options)
+  end
+
+  def TestUtils.tokenize_as_list(input_string)
+    token_iterator = tokenize(input_string)
 
     token_list = []
 
@@ -74,11 +78,11 @@ module TestUtils
     Tokens.new_substitution(fake_origin(), optional, token_list)
   end
 
-  def TestUtils.token_substitution(token_list)
+  def TestUtils.token_substitution(*token_list)
     token_maybe_optional_substitution(false, token_list)
   end
 
-  def TestUtils.token_optional_substitution(token_list)
+  def TestUtils.token_optional_substitution(*token_list)
     token_maybe_optional_substitution(true, token_list)
   end
 

--- a/spec/test_utils.rb
+++ b/spec/test_utils.rb
@@ -1,0 +1,88 @@
+require 'hocon'
+
+module TestUtils
+  Tokens = Hocon::Impl::Tokens
+  EOF = Hocon::Impl::TokenType::EOF
+
+  def TestUtils.wrap_tokens(token_list)
+    # Wraps token_list in START and EOF tokens
+    [Tokens::START] + token_list + [Tokens::EOF]
+  end
+
+  def TestUtils.tokenize_as_list(input_string)
+    origin = Hocon::Impl::SimpleConfigOrigin.new_simple("test")
+    options = Hocon::ConfigParseOptions.defaults
+    io = StringIO.open(input_string)
+
+    token_iterator =  Hocon::Impl::Tokenizer.tokenize(origin, io, options)
+
+    token_list = []
+
+    while true
+      token = token_iterator.next
+      token_list.push token
+
+      if token.token_type == EOF
+        break
+      end
+    end
+
+    token_list
+  end
+
+  def TestUtils.fake_origin
+    Hocon::Impl::SimpleConfigOrigin.new_simple("fake origin")
+  end
+
+  def TestUtils.token_line(line_number)
+    Tokens.new_line(fake_origin.set_line_number(line_number))
+  end
+
+  def TestUtils.token_true
+    Tokens.new_boolean(fake_origin, true)
+  end
+
+  def TestUtils.token_false
+    Tokens.new_boolean(fake_origin, false)
+  end
+
+  def TestUtils.token_null
+    Tokens.new_null(fake_origin)
+  end
+
+  def TestUtils.token_unquoted(value)
+    Tokens.new_unquoted_text(fake_origin, value)
+  end
+
+  def TestUtils.token_comment(value)
+    Tokens.new_comment(fake_origin, value)
+  end
+
+  def TestUtils.token_string(value)
+    Tokens.new_string(fake_origin, value)
+  end
+
+  def TestUtils.token_float(value)
+    Tokens.new_float(fake_origin, value, nil)
+  end
+
+  def TestUtils.token_int(value)
+    Tokens.new_int(fake_origin, value, nil)
+  end
+
+  def TestUtils.token_maybe_optional_substitution(optional, token_list)
+    Tokens.new_substitution(fake_origin(), optional, token_list)
+  end
+
+  def TestUtils.token_substitution(token_list)
+    token_maybe_optional_substitution(false, token_list)
+  end
+
+  def TestUtils.token_optional_substitution(token_list)
+    token_maybe_optional_substitution(true, token_list)
+  end
+
+  def TestUtils.token_key_substitution(value)
+    token_substitution(token_string(value))
+  end
+end

--- a/spec/unit/typesafe/config/tokenizer_spec.rb
+++ b/spec/unit/typesafe/config/tokenizer_spec.rb
@@ -1,0 +1,696 @@
+require 'spec_helper'
+require 'hocon'
+require 'test_utils'
+require 'pp'
+
+
+describe Hocon::Impl::Tokenizer do
+  Tokens = Hocon::Impl::Tokens
+
+  shared_examples_for "token_matching" do
+    it "should match the tokenized string to the list of expected tokens" do
+      tokenized_from_string = TestUtils.tokenize_as_list(test_string)
+
+      # Add START and EOF tokens
+      wrapped_tokens = TestUtils.wrap_tokens(expected_tokens)
+
+      # puts "\n\n===Expected String: #{test_string}"
+      # PP.pp(tokenized_from_string)
+
+      # Compare the two lists of tokens
+      expect(tokenized_from_string).to eq(wrapped_tokens)
+    end
+  end
+
+  shared_examples_for "strings_with_problems" do
+    it "should find a problem when tokenizing" do
+      token_list = TestUtils.tokenize_as_list(test_string)
+      expect(token_list.map { |token| Tokens.problem?(token) }).to include(true)
+    end
+  end
+
+  ####################
+  # Whitespace
+  ####################
+  context "tokenize empty string" do
+    let(:test_string) { "" }
+    let(:expected_tokens) { [] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize newlines" do
+    let(:test_string) { "\n\n" }
+    let(:expected_tokens) { [TestUtils.token_line(1),
+                             TestUtils.token_line(2)] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize unquoted text should trim spaces" do
+    let(:test_string) { "    foo     \n" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("foo"), TestUtils.token_line(1)] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize unquoted text should trim spaces, keep internal spaces" do
+    let(:test_string) { "    foo  bar baz   \n" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_unquoted("bar"),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_unquoted("baz"),
+                             TestUtils.token_line(1)] }
+
+    include_examples "token_matching"
+  end
+
+  ####################
+  # Booleans
+  ####################
+  context "tokenize true and unquoted text" do
+    let(:test_string) { "truefoo" }
+    let(:expected_tokens) { [TestUtils.token_true,
+                             TestUtils.token_unquoted("foo")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize false and unquoted text" do
+    let(:test_string) { "falsefoo" }
+    let(:expected_tokens) { [TestUtils.token_false,
+                             TestUtils.token_unquoted("foo")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize null and unquoted text" do
+    let(:test_string) { "nullfoo" }
+    let(:expected_tokens) { [TestUtils.token_null,
+                             TestUtils.token_unquoted("foo")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize unquoted text containing true" do
+    let(:test_string) { "footrue" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("footrue")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize unquoted text containing space and true" do
+    let(:test_string) { "foo true" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_true] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize true and space and unquoted text" do
+    let(:test_string) { "true foo" }
+    let(:expected_tokens) { [TestUtils.token_true,
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_unquoted("foo")] }
+
+    include_examples "token_matching"
+  end
+
+  ####################
+  # Slashes
+  ####################
+  context "tokenize unquoted text containing slash" do
+    let(:test_string) { "a/b/c/" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("a/b/c/")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize slash" do
+    let(:test_string) { "/" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("/")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize slash space slash" do
+    let(:test_string) { "/ /" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("/"),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_unquoted("/")] }
+
+    include_examples "token_matching"
+  end
+
+  ####################
+  # Quotes
+  ####################
+  context "tokenize mixed unquoted and quoted" do
+    let(:test_string) { "    foo\"bar\"baz   \n" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
+                             TestUtils.token_string("bar"),
+                             TestUtils.token_unquoted("baz"),
+                             TestUtils.token_line(1)] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize empty triple quoted string" do
+    let(:test_string) { "\"\"\"\"\"\"" }
+    let(:expected_tokens) { [TestUtils.token_string("")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize trivial triple quoted string" do
+    let(:test_string) { "\"\"\"bar\"\"\"" }
+    let(:expected_tokens) { [TestUtils.token_string("bar")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize no escapes in triple quoted string" do
+    let(:test_string) { "\"\"\"\\n\"\"\"" }
+    let(:expected_tokens) { [TestUtils.token_string("\\n")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize trailing quotes in triple quoted string" do
+    let(:test_string) { "\"\"\"\"\"\"\"\"\"" }
+    let(:expected_tokens) { [TestUtils.token_string("\"\"\"")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize new line in triple quoted string" do
+    let(:test_string) { "\"\"\"foo\nbar\"\"\"" }
+    let(:expected_tokens) { [TestUtils.token_string("foo\nbar")] }
+
+    include_examples "token_matching"
+  end
+
+
+  ####################
+  # Find problems when tokenizing
+  ####################
+  context "problem nothing after backslash" do
+    let(:test_string) { " \"\\\" " }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem there is no \q escape sequence" do
+    let(:test_string) { " \"\\q\" " }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem too short" do
+    let(:test_string) { "\"\\u123\"" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem too short" do
+    let(:test_string) { "\"\\u12\"" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem too short" do
+    let(:test_string) { "\"\\u1\"" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem too short" do
+    let(:test_string) { "\"\\u\"" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem just a single quote" do
+    let(:test_string) { "\"" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem no end quote" do
+    let(:test_string) { " \"abcdefg" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem file ends with a backslash" do
+    let(:test_string) { "\\\"\\" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem file ends with a $" do
+    let(:test_string) { "$" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem file ends with a ${" do
+    let(:test_string) { "${" }
+    include_examples "strings_with_problems"
+  end
+
+  ####################
+  # Numbers
+  ####################
+  context "parse positive float" do
+    let(:test_string) { "1.2" }
+    let(:expected_tokens) { [TestUtils.token_float(1.2)] }
+    include_examples "token_matching"
+  end
+
+  context "parse negative float" do
+    let(:test_string) { "-1.2" }
+    let(:expected_tokens) { [TestUtils.token_float(-1.2)] }
+    include_examples "token_matching"
+  end
+
+  context "parse exponent notation" do
+    let(:test_string) { "1e6" }
+    let(:expected_tokens) { [TestUtils.token_float(1e6)] }
+    include_examples "token_matching"
+  end
+
+  context "parse negative exponent" do
+    let(:test_string) { "1e-6" }
+    let(:expected_tokens) { [TestUtils.token_float(1e-6)] }
+    include_examples "token_matching"
+  end
+
+  context "parse exponent with capital E" do
+    let(:test_string) { "1E-6" }
+    let(:expected_tokens) { [TestUtils.token_float(1e-6)] }
+    include_examples "token_matching"
+  end
+
+  context "parse negative int" do
+    let(:test_string) { "-1" }
+    let(:expected_tokens) { [TestUtils.token_int(-1)] }
+    include_examples "token_matching"
+  end
+
+
+  ####################
+  # Comments
+  ####################
+  context "tokenize two slashes as comment" do
+    let(:test_string) { "//" }
+    let(:expected_tokens) { [TestUtils.token_comment("")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize two slashes in string as string" do
+    let(:test_string) { "\"//bar\"" }
+    let(:expected_tokens) { [TestUtils.token_string("//bar")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize hash in string as string" do
+    let(:test_string) { "\"#bar\"" }
+    let(:expected_tokens) { [TestUtils.token_string("#bar")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize slash comment after unquoted text" do
+    let(:test_string) { "bar//comment" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("bar"),
+                             TestUtils.token_comment("comment")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize hash comment after unquoted text" do
+    let(:test_string) { "bar#comment" }
+    let(:expected_tokens) { [TestUtils.token_unquoted("bar"),
+                             TestUtils.token_comment("comment")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize slash comment after int" do
+    let(:test_string) { "10//comment" }
+    let(:expected_tokens) { [TestUtils.token_int(10),
+                             TestUtils.token_comment("comment")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize hash comment after int" do
+    let(:test_string) { "10#comment" }
+    let(:expected_tokens) { [TestUtils.token_int(10),
+                             TestUtils.token_comment("comment")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize hash comment after int" do
+    let(:test_string) { "10#comment" }
+    let(:expected_tokens) { [TestUtils.token_int(10),
+                             TestUtils.token_comment("comment")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize slash comment after float" do
+    let(:test_string) { "3.14//comment" }
+    let(:expected_tokens) { [TestUtils.token_float(3.14),
+                             TestUtils.token_comment("comment")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize hash comment after float" do
+    let(:test_string) { "3.14#comment" }
+    let(:expected_tokens) { [TestUtils.token_float(3.14),
+                             TestUtils.token_comment("comment")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize slash comment with newline" do
+    let(:test_string) { "10//comment\n12" }
+    let(:expected_tokens) { [TestUtils.token_int(10),
+                             TestUtils.token_comment("comment"),
+                             TestUtils.token_line(1),
+                             TestUtils.token_int(12)] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize hash comment with newline" do
+    let(:test_string) { "10#comment\n12" }
+    let(:expected_tokens) { [TestUtils.token_int(10),
+                             TestUtils.token_comment("comment"),
+                             TestUtils.token_line(1),
+                             TestUtils.token_int(12)] }
+
+    include_examples "token_matching"
+  end
+
+  ####################
+  # Brackets, braces
+  ####################
+  context "tokenize open curly braces" do
+    let(:test_string) { "{{" }
+    let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::OPEN_CURLY] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize close curly braces" do
+    let(:test_string) { "}}" }
+    let(:expected_tokens) { [Tokens::CLOSE_CURLY, Tokens::CLOSE_CURLY] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize open and close curly braces" do
+    let(:test_string) { "{}" }
+    let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::CLOSE_CURLY] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize open and close curly braces" do
+    let(:test_string) { "{}" }
+    let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::CLOSE_CURLY] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize open square brackets" do
+    let(:test_string) { "[[" }
+    let(:expected_tokens) { [Tokens::OPEN_SQUARE, Tokens::OPEN_SQUARE] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize close square brackets" do
+    let(:test_string) { "]]" }
+    let(:expected_tokens) { [Tokens::CLOSE_SQUARE, Tokens::CLOSE_SQUARE] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize open and close square brackets" do
+    let(:test_string) { "[]" }
+    let(:expected_tokens) { [Tokens::OPEN_SQUARE, Tokens::CLOSE_SQUARE] }
+
+    include_examples "token_matching"
+  end
+
+  ####################
+  # comma, colon, equals, plus equals
+  ####################
+  context "tokenize comma" do
+    let(:test_string) { "," }
+    let(:expected_tokens) { [Tokens::COMMA] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize colon" do
+    let(:test_string) { ":" }
+    let(:expected_tokens) { [Tokens::COLON] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize equals" do
+    let(:test_string) { "=" }
+    let(:expected_tokens) { [Tokens::EQUALS] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize plus equals" do
+    let(:test_string) { "+=" }
+    let(:expected_tokens) { [Tokens::PLUS_EQUALS] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize comma, colon, plus equals, and equals together" do
+    let(:test_string) { "=:,+=" }
+    let(:expected_tokens) { [Tokens::EQUALS,
+                             Tokens::COLON,
+                             Tokens::COMMA,
+                             Tokens::PLUS_EQUALS] }
+
+    include_examples "token_matching"
+  end
+
+
+  ####################
+  # Substitutions
+  ####################
+  context "tokenize substitution" do
+    let(:test_string) { "${a.b}" }
+    let(:expected_tokens) { [TestUtils.token_substitution([TestUtils.token_unquoted("a.b")])] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize optional substitution" do
+    let(:test_string) { "${?x.y}" }
+    let(:expected_tokens) { [TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y"))] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize key substitution" do
+    let(:test_string) { "${?x.y}" }
+    let(:expected_tokens) { [TestUtils.token_key_substitution(TestUtils.token_unquoted("x.y"))] }
+
+    include_examples "token_matching"
+  end
+
+  ####################
+  # Unicode
+  ####################
+  context "tokenize unicode character" do
+    let(:test_string) { "\"\\u221E\"" }
+    let(:expected_tokens) { [TestUtils.token_string("\u{221E}")] }
+
+    include_examples "token_matching"
+  end
+
+  ####################
+  # Escaped Strings
+  ####################
+  context "tokenize null byte" do
+    let(:test_string) { " \"\\u0000\" " }
+    let(:expected_tokens) { [TestUtils.token_string("\u0000")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize various espace codes" do
+    let(:test_string) { " \"\\\"\\\\\\/\\b\\f\\n\\r\\t\"" }
+    let(:expected_tokens) { [TestUtils.token_string("\"\\/\b\f\n\r\t")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize unicode F" do
+    let(:test_string) { "\"\\u0046\"" }
+    let(:expected_tokens) { [TestUtils.token_string("F")] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize two unicode Fs" do
+    let(:test_string) { "\"\\u0046\\u0046\"" }
+    let(:expected_tokens) { [TestUtils.token_string("FF")] }
+
+    include_examples "token_matching"
+  end
+
+  ####################
+  # Combine all types
+  ####################
+  context "problem with reserved character +" do
+    let(:test_string) { "+" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem with reserved character `" do
+    let(:test_string) { "`" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem with reserved character ^" do
+    let(:test_string) { "^" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem with reserved character ?" do
+    let(:test_string) { "?" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem with reserved character !" do
+    let(:test_string) { "!" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem with reserved character @" do
+    let(:test_string) { "@" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem with reserved character *" do
+    let(:test_string) { "*" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem with reserved character &" do
+    let(:test_string) { "&" }
+    include_examples "strings_with_problems"
+  end
+
+  context "problem with reserved character \\" do
+    let(:test_string) { "\\" }
+    include_examples "strings_with_problems"
+  end
+
+  ####################
+  # Combine all types
+  ####################
+  context "tokenize all types no spaces" do
+    let(:test_string) { ",:=}{][+=\"foo\"\"\"\"bar\"\"\"true3.14false42null${a.b}${?x.y}${\"c.d\"}\n" }
+    let(:expected_tokens) { [Tokens::COMMA,
+                             Tokens::COLON,
+                             Tokens::EQUALS,
+                             Tokens::CLOSE_CURLY,
+                             Tokens::OPEN_CURLY,
+                             Tokens::CLOSE_SQUARE,
+                             Tokens::OPEN_SQUARE,
+                             Tokens::PLUS_EQUALS,
+                             TestUtils.token_string("foo"),
+                             TestUtils.token_string("bar"),
+                             TestUtils.token_true,
+                             TestUtils.token_float(3.14),
+                             TestUtils.token_false,
+                             TestUtils.token_int(42),
+                             TestUtils.token_null,
+                             TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
+                             TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
+                             TestUtils.token_key_substitution("c.d"),
+                             TestUtils.token_line(1)] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize all types single spaces" do
+    let(:test_string) { " , : = } { ] [ += \"foo\" \"\"\"bar\"\"\" 42 true 3.14 false null ${a.b} ${?x.y} ${\"c.d\"} \n " }
+    let(:expected_tokens) { [Tokens::COMMA,
+                             Tokens::COLON,
+                             Tokens::EQUALS,
+                             Tokens::CLOSE_CURLY,
+                             Tokens::OPEN_CURLY,
+                             Tokens::CLOSE_SQUARE,
+                             Tokens::OPEN_SQUARE,
+                             Tokens::PLUS_EQUALS,
+                             TestUtils.token_string("foo"),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_string("bar"),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_int(42),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_true,
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_float(3.14),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_false,
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_null,
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
+                             TestUtils.token_unquoted(" "),
+                             TestUtils.token_key_substitution("c.d"),
+                             TestUtils.token_line(1)] }
+
+    include_examples "token_matching"
+  end
+
+  context "tokenize all types multiple spaces" do
+    let(:test_string) { "   ,   :   =   }   {   ]   [   +=   \"foo\"   \"\"\"bar\"\"\"   42   true   3.14   false   null   ${a.b}   ${?x.y}   ${\"c.d\"}   \n   " }
+    let(:expected_tokens) { [Tokens::COMMA,
+                             Tokens::COLON,
+                             Tokens::EQUALS,
+                             Tokens::CLOSE_CURLY,
+                             Tokens::OPEN_CURLY,
+                             Tokens::CLOSE_SQUARE,
+                             Tokens::OPEN_SQUARE,
+                             Tokens::PLUS_EQUALS,
+                             TestUtils.token_string("foo"),
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_string("bar"),
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_int(42),
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_true,
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_float(3.14),
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_false,
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_null,
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
+                             TestUtils.token_unquoted("   "),
+                             TestUtils.token_key_substitution("c.d"),
+                             TestUtils.token_line(1)] }
+
+    include_examples "token_matching"
+  end
+end

--- a/spec/unit/typesafe/config/tokenizer_spec.rb
+++ b/spec/unit/typesafe/config/tokenizer_spec.rb
@@ -14,9 +14,6 @@ describe Hocon::Impl::Tokenizer do
       # Add START and EOF tokens
       wrapped_tokens = TestUtils.wrap_tokens(expected_tokens)
 
-      # puts "\n\n===Expected String: #{test_string}"
-      # PP.pp(tokenized_from_string)
-
       # Compare the two lists of tokens
       expect(tokenized_from_string).to eq(wrapped_tokens)
     end
@@ -32,665 +29,683 @@ describe Hocon::Impl::Tokenizer do
   ####################
   # Whitespace
   ####################
-  context "tokenize empty string" do
-    let(:test_string) { "" }
-    let(:expected_tokens) { [] }
+  context "tokenizing whitespace" do
+    context "tokenize empty string" do
+      let(:test_string) { "" }
+      let(:expected_tokens) { [] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize newlines" do
-    let(:test_string) { "\n\n" }
-    let(:expected_tokens) { [TestUtils.token_line(1),
-                             TestUtils.token_line(2)] }
+    context "tokenize newlines" do
+      let(:test_string) { "\n\n" }
+      let(:expected_tokens) { [TestUtils.token_line(1),
+                               TestUtils.token_line(2)] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize unquoted text should trim spaces" do
-    let(:test_string) { "    foo     \n" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("foo"), TestUtils.token_line(1)] }
+    context "tokenize unquoted text should trim spaces" do
+      let(:test_string) { "    foo     \n" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("foo"), TestUtils.token_line(1)] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize unquoted text should trim spaces, keep internal spaces" do
-    let(:test_string) { "    foo  bar baz   \n" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_unquoted("bar"),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_unquoted("baz"),
-                             TestUtils.token_line(1)] }
+    context "tokenize unquoted text should trim spaces, keep internal spaces" do
+      let(:test_string) { "    foo bar baz   \n" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_unquoted("bar"),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_unquoted("baz"),
+                               TestUtils.token_line(1)] }
 
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
   end
 
   ####################
-  # Booleans
+  # Booleans and Null
   ####################
-  context "tokenize true and unquoted text" do
-    let(:test_string) { "truefoo" }
-    let(:expected_tokens) { [TestUtils.token_true,
-                             TestUtils.token_unquoted("foo")] }
+  context "tokenizing booleans and null" do
+    context "tokenize true and unquoted text" do
+      let(:test_string) { "truefoo" }
+      let(:expected_tokens) { [TestUtils.token_true,
+                               TestUtils.token_unquoted("foo")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize false and unquoted text" do
-    let(:test_string) { "falsefoo" }
-    let(:expected_tokens) { [TestUtils.token_false,
-                             TestUtils.token_unquoted("foo")] }
+    context "tokenize false and unquoted text" do
+      let(:test_string) { "falsefoo" }
+      let(:expected_tokens) { [TestUtils.token_false,
+                               TestUtils.token_unquoted("foo")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize null and unquoted text" do
-    let(:test_string) { "nullfoo" }
-    let(:expected_tokens) { [TestUtils.token_null,
-                             TestUtils.token_unquoted("foo")] }
+    context "tokenize null and unquoted text" do
+      let(:test_string) { "nullfoo" }
+      let(:expected_tokens) { [TestUtils.token_null,
+                               TestUtils.token_unquoted("foo")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize unquoted text containing true" do
-    let(:test_string) { "footrue" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("footrue")] }
+    context "tokenize unquoted text containing true" do
+      let(:test_string) { "footrue" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("footrue")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize unquoted text containing space and true" do
-    let(:test_string) { "foo true" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_true] }
+    context "tokenize unquoted text containing space and true" do
+      let(:test_string) { "foo true" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_true] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize true and space and unquoted text" do
-    let(:test_string) { "true foo" }
-    let(:expected_tokens) { [TestUtils.token_true,
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_unquoted("foo")] }
+    context "tokenize true and space and unquoted text" do
+      let(:test_string) { "true foo" }
+      let(:expected_tokens) { [TestUtils.token_true,
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_unquoted("foo")] }
 
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
   end
 
   ####################
   # Slashes
   ####################
-  context "tokenize unquoted text containing slash" do
-    let(:test_string) { "a/b/c/" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("a/b/c/")] }
+  context "tokenizing slashes" do
+    context "tokenize unquoted text containing slash" do
+      let(:test_string) { "a/b/c/" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("a/b/c/")] }
 
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
+
+    context "tokenize slash" do
+      let(:test_string) { "/" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("/")] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize slash space slash" do
+      let(:test_string) { "/ /" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("/"),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_unquoted("/")] }
+
+      include_examples "token_matching"
+    end
+
+    ####################
+    # Quotes
+    ####################
+    context "tokenize mixed unquoted and quoted" do
+      let(:test_string) { "    foo\"bar\"baz   \n" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
+                               TestUtils.token_string("bar"),
+                               TestUtils.token_unquoted("baz"),
+                               TestUtils.token_line(1)] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize empty triple quoted string" do
+      let(:test_string) { '""""""' }
+      let(:expected_tokens) { [TestUtils.token_string("")] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize trivial triple quoted string" do
+      let(:test_string) { '"""bar"""' }
+      let(:expected_tokens) { [TestUtils.token_string("bar")] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize no escapes in triple quoted string" do
+      let(:test_string) { '"""\n"""' }
+      let(:expected_tokens) { [TestUtils.token_string('\n')] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize trailing quotes in triple quoted string" do
+      let(:test_string) { '"""""""""' }
+      let(:expected_tokens) { [TestUtils.token_string('"""')] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize new line in triple quoted string" do
+      let(:test_string) { '"""foo\nbar"""' }
+      let(:expected_tokens) { [TestUtils.token_string('foo\nbar')] }
+
+      include_examples "token_matching"
+    end
   end
-
-  context "tokenize slash" do
-    let(:test_string) { "/" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("/")] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize slash space slash" do
-    let(:test_string) { "/ /" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("/"),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_unquoted("/")] }
-
-    include_examples "token_matching"
-  end
-
-  ####################
-  # Quotes
-  ####################
-  context "tokenize mixed unquoted and quoted" do
-    let(:test_string) { "    foo\"bar\"baz   \n" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("foo"),
-                             TestUtils.token_string("bar"),
-                             TestUtils.token_unquoted("baz"),
-                             TestUtils.token_line(1)] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize empty triple quoted string" do
-    let(:test_string) { "\"\"\"\"\"\"" }
-    let(:expected_tokens) { [TestUtils.token_string("")] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize trivial triple quoted string" do
-    let(:test_string) { "\"\"\"bar\"\"\"" }
-    let(:expected_tokens) { [TestUtils.token_string("bar")] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize no escapes in triple quoted string" do
-    let(:test_string) { "\"\"\"\\n\"\"\"" }
-    let(:expected_tokens) { [TestUtils.token_string("\\n")] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize trailing quotes in triple quoted string" do
-    let(:test_string) { "\"\"\"\"\"\"\"\"\"" }
-    let(:expected_tokens) { [TestUtils.token_string("\"\"\"")] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize new line in triple quoted string" do
-    let(:test_string) { "\"\"\"foo\nbar\"\"\"" }
-    let(:expected_tokens) { [TestUtils.token_string("foo\nbar")] }
-
-    include_examples "token_matching"
-  end
-
 
   ####################
   # Find problems when tokenizing
   ####################
-  context "problem nothing after backslash" do
-    let(:test_string) { " \"\\\" " }
-    include_examples "strings_with_problems"
-  end
+  context "finding problems when tokenizing" do
+    context "nothing after backslash" do
+      let(:test_string) { ' "\" ' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem there is no \q escape sequence" do
-    let(:test_string) { " \"\\q\" " }
-    include_examples "strings_with_problems"
-  end
+    context "there is no \q escape sequence" do
+      let(:test_string) { ' "\q" ' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem too short" do
-    let(:test_string) { "\"\\u123\"" }
-    include_examples "strings_with_problems"
-  end
+    context "unicode byte sequence missing a byte" do
+      let(:test_string) { '"\u123"' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem too short" do
-    let(:test_string) { "\"\\u12\"" }
-    include_examples "strings_with_problems"
-  end
+    context "unicode byte sequence missing two bytes" do
+      let(:test_string) { '"\u12"' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem too short" do
-    let(:test_string) { "\"\\u1\"" }
-    include_examples "strings_with_problems"
-  end
+    context "unicode byte sequence missing three bytes" do
+      let(:test_string) { '"\u1"' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem too short" do
-    let(:test_string) { "\"\\u\"" }
-    include_examples "strings_with_problems"
-  end
+    context "unicode byte missing" do
+      let(:test_string) { '"\u"' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem just a single quote" do
-    let(:test_string) { "\"" }
-    include_examples "strings_with_problems"
-  end
+    context "just a single quote" do
+      let(:test_string) { '"' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem no end quote" do
-    let(:test_string) { " \"abcdefg" }
-    include_examples "strings_with_problems"
-  end
+    context "no end quote" do
+      let(:test_string) { ' "abcdefg' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem file ends with a backslash" do
-    let(:test_string) { "\\\"\\" }
-    include_examples "strings_with_problems"
-  end
+    context "file ends with a backslash" do
+      let(:test_string) { '\"\\' }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem file ends with a $" do
-    let(:test_string) { "$" }
-    include_examples "strings_with_problems"
-  end
+    context "file ends with a $" do
+      let(:test_string) { "$" }
+      include_examples "strings_with_problems"
+    end
 
-  context "problem file ends with a ${" do
-    let(:test_string) { "${" }
-    include_examples "strings_with_problems"
+    context "file ends with a ${" do
+      let(:test_string) { "${" }
+      include_examples "strings_with_problems"
+    end
   end
 
   ####################
   # Numbers
   ####################
-  context "parse positive float" do
-    let(:test_string) { "1.2" }
-    let(:expected_tokens) { [TestUtils.token_float(1.2)] }
-    include_examples "token_matching"
-  end
+  context "tokenizing numbers" do
+    context "parse positive float" do
+      let(:test_string) { "1.2" }
+      let(:expected_tokens) { [TestUtils.token_float(1.2)] }
+      include_examples "token_matching"
+    end
 
-  context "parse negative float" do
-    let(:test_string) { "-1.2" }
-    let(:expected_tokens) { [TestUtils.token_float(-1.2)] }
-    include_examples "token_matching"
-  end
+    context "parse negative float" do
+      let(:test_string) { "-1.2" }
+      let(:expected_tokens) { [TestUtils.token_float(-1.2)] }
+      include_examples "token_matching"
+    end
 
-  context "parse exponent notation" do
-    let(:test_string) { "1e6" }
-    let(:expected_tokens) { [TestUtils.token_float(1e6)] }
-    include_examples "token_matching"
-  end
+    context "parse exponent notation" do
+      let(:test_string) { "1e6" }
+      let(:expected_tokens) { [TestUtils.token_float(1e6)] }
+      include_examples "token_matching"
+    end
 
-  context "parse negative exponent" do
-    let(:test_string) { "1e-6" }
-    let(:expected_tokens) { [TestUtils.token_float(1e-6)] }
-    include_examples "token_matching"
-  end
+    context "parse negative exponent" do
+      let(:test_string) { "1e-6" }
+      let(:expected_tokens) { [TestUtils.token_float(1e-6)] }
+      include_examples "token_matching"
+    end
 
-  context "parse exponent with capital E" do
-    let(:test_string) { "1E-6" }
-    let(:expected_tokens) { [TestUtils.token_float(1e-6)] }
-    include_examples "token_matching"
-  end
+    context "parse exponent with capital E" do
+      let(:test_string) { "1E-6" }
+      let(:expected_tokens) { [TestUtils.token_float(1e-6)] }
+      include_examples "token_matching"
+    end
 
-  context "parse negative int" do
-    let(:test_string) { "-1" }
-    let(:expected_tokens) { [TestUtils.token_int(-1)] }
-    include_examples "token_matching"
+    context "parse negative int" do
+      let(:test_string) { "-1" }
+      let(:expected_tokens) { [TestUtils.token_int(-1)] }
+      include_examples "token_matching"
+    end
   end
-
 
   ####################
   # Comments
   ####################
-  context "tokenize two slashes as comment" do
-    let(:test_string) { "//" }
-    let(:expected_tokens) { [TestUtils.token_comment("")] }
+  context "tokenizing comments" do
+    context "tokenize two slashes as comment" do
+      let(:test_string) { "//" }
+      let(:expected_tokens) { [TestUtils.token_comment("")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize two slashes in string as string" do
-    let(:test_string) { "\"//bar\"" }
-    let(:expected_tokens) { [TestUtils.token_string("//bar")] }
+    context "tokenize two slashes in string as string" do
+      let(:test_string) { '"//bar"' }
+      let(:expected_tokens) { [TestUtils.token_string("//bar")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize hash in string as string" do
-    let(:test_string) { "\"#bar\"" }
-    let(:expected_tokens) { [TestUtils.token_string("#bar")] }
+    context "tokenize hash in string as string" do
+      let(:test_string) { '"#bar"' }
+      let(:expected_tokens) { [TestUtils.token_string("#bar")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize slash comment after unquoted text" do
-    let(:test_string) { "bar//comment" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("bar"),
-                             TestUtils.token_comment("comment")] }
+    context "tokenize slash comment after unquoted text" do
+      let(:test_string) { "bar//comment" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("bar"),
+                               TestUtils.token_comment("comment")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize hash comment after unquoted text" do
-    let(:test_string) { "bar#comment" }
-    let(:expected_tokens) { [TestUtils.token_unquoted("bar"),
-                             TestUtils.token_comment("comment")] }
+    context "tokenize hash comment after unquoted text" do
+      let(:test_string) { "bar#comment" }
+      let(:expected_tokens) { [TestUtils.token_unquoted("bar"),
+                               TestUtils.token_comment("comment")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize slash comment after int" do
-    let(:test_string) { "10//comment" }
-    let(:expected_tokens) { [TestUtils.token_int(10),
-                             TestUtils.token_comment("comment")] }
+    context "tokenize slash comment after int" do
+      let(:test_string) { "10//comment" }
+      let(:expected_tokens) { [TestUtils.token_int(10),
+                               TestUtils.token_comment("comment")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize hash comment after int" do
-    let(:test_string) { "10#comment" }
-    let(:expected_tokens) { [TestUtils.token_int(10),
-                             TestUtils.token_comment("comment")] }
+    context "tokenize hash comment after int" do
+      let(:test_string) { "10#comment" }
+      let(:expected_tokens) { [TestUtils.token_int(10),
+                               TestUtils.token_comment("comment")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize hash comment after int" do
-    let(:test_string) { "10#comment" }
-    let(:expected_tokens) { [TestUtils.token_int(10),
-                             TestUtils.token_comment("comment")] }
+    context "tokenize hash comment after int" do
+      let(:test_string) { "10#comment" }
+      let(:expected_tokens) { [TestUtils.token_int(10),
+                               TestUtils.token_comment("comment")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize slash comment after float" do
-    let(:test_string) { "3.14//comment" }
-    let(:expected_tokens) { [TestUtils.token_float(3.14),
-                             TestUtils.token_comment("comment")] }
+    context "tokenize slash comment after float" do
+      let(:test_string) { "3.14//comment" }
+      let(:expected_tokens) { [TestUtils.token_float(3.14),
+                               TestUtils.token_comment("comment")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize hash comment after float" do
-    let(:test_string) { "3.14#comment" }
-    let(:expected_tokens) { [TestUtils.token_float(3.14),
-                             TestUtils.token_comment("comment")] }
+    context "tokenize hash comment after float" do
+      let(:test_string) { "3.14#comment" }
+      let(:expected_tokens) { [TestUtils.token_float(3.14),
+                               TestUtils.token_comment("comment")] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize slash comment with newline" do
-    let(:test_string) { "10//comment\n12" }
-    let(:expected_tokens) { [TestUtils.token_int(10),
-                             TestUtils.token_comment("comment"),
-                             TestUtils.token_line(1),
-                             TestUtils.token_int(12)] }
+    context "tokenize slash comment with newline" do
+      let(:test_string) { "10//comment\n12" }
+      let(:expected_tokens) { [TestUtils.token_int(10),
+                               TestUtils.token_comment("comment"),
+                               TestUtils.token_line(1),
+                               TestUtils.token_int(12)] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize hash comment with newline" do
-    let(:test_string) { "10#comment\n12" }
-    let(:expected_tokens) { [TestUtils.token_int(10),
-                             TestUtils.token_comment("comment"),
-                             TestUtils.token_line(1),
-                             TestUtils.token_int(12)] }
+    context "tokenize hash comment with newline" do
+      let(:test_string) { "10#comment\n12" }
+      let(:expected_tokens) { [TestUtils.token_int(10),
+                               TestUtils.token_comment("comment"),
+                               TestUtils.token_line(1),
+                               TestUtils.token_int(12)] }
 
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
   end
 
   ####################
   # Brackets, braces
   ####################
-  context "tokenize open curly braces" do
-    let(:test_string) { "{{" }
-    let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::OPEN_CURLY] }
+  context "tokenizing brackets and braces" do
+    context "tokenize open curly braces" do
+      let(:test_string) { "{{" }
+      let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::OPEN_CURLY] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize close curly braces" do
-    let(:test_string) { "}}" }
-    let(:expected_tokens) { [Tokens::CLOSE_CURLY, Tokens::CLOSE_CURLY] }
+    context "tokenize close curly braces" do
+      let(:test_string) { "}}" }
+      let(:expected_tokens) { [Tokens::CLOSE_CURLY, Tokens::CLOSE_CURLY] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize open and close curly braces" do
-    let(:test_string) { "{}" }
-    let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::CLOSE_CURLY] }
+    context "tokenize open and close curly braces" do
+      let(:test_string) { "{}" }
+      let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::CLOSE_CURLY] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize open and close curly braces" do
-    let(:test_string) { "{}" }
-    let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::CLOSE_CURLY] }
+    context "tokenize open and close curly braces" do
+      let(:test_string) { "{}" }
+      let(:expected_tokens) { [Tokens::OPEN_CURLY, Tokens::CLOSE_CURLY] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize open square brackets" do
-    let(:test_string) { "[[" }
-    let(:expected_tokens) { [Tokens::OPEN_SQUARE, Tokens::OPEN_SQUARE] }
+    context "tokenize open square brackets" do
+      let(:test_string) { "[[" }
+      let(:expected_tokens) { [Tokens::OPEN_SQUARE, Tokens::OPEN_SQUARE] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize close square brackets" do
-    let(:test_string) { "]]" }
-    let(:expected_tokens) { [Tokens::CLOSE_SQUARE, Tokens::CLOSE_SQUARE] }
+    context "tokenize close square brackets" do
+      let(:test_string) { "]]" }
+      let(:expected_tokens) { [Tokens::CLOSE_SQUARE, Tokens::CLOSE_SQUARE] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize open and close square brackets" do
-    let(:test_string) { "[]" }
-    let(:expected_tokens) { [Tokens::OPEN_SQUARE, Tokens::CLOSE_SQUARE] }
+    context "tokenize open and close square brackets" do
+      let(:test_string) { "[]" }
+      let(:expected_tokens) { [Tokens::OPEN_SQUARE, Tokens::CLOSE_SQUARE] }
 
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
   end
 
   ####################
   # comma, colon, equals, plus equals
   ####################
-  context "tokenize comma" do
-    let(:test_string) { "," }
-    let(:expected_tokens) { [Tokens::COMMA] }
+  context "tokenizing comma, colon, equals, and plus equals" do
+    context "tokenize comma" do
+      let(:test_string) { "," }
+      let(:expected_tokens) { [Tokens::COMMA] }
 
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
+
+    context "tokenize colon" do
+      let(:test_string) { ":" }
+      let(:expected_tokens) { [Tokens::COLON] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize equals" do
+      let(:test_string) { "=" }
+      let(:expected_tokens) { [Tokens::EQUALS] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize plus equals" do
+      let(:test_string) { "+=" }
+      let(:expected_tokens) { [Tokens::PLUS_EQUALS] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize comma, colon, plus equals, and equals together" do
+      let(:test_string) { "=:,+=" }
+      let(:expected_tokens) { [Tokens::EQUALS,
+                               Tokens::COLON,
+                               Tokens::COMMA,
+                               Tokens::PLUS_EQUALS] }
+
+      include_examples "token_matching"
+    end
   end
-
-  context "tokenize colon" do
-    let(:test_string) { ":" }
-    let(:expected_tokens) { [Tokens::COLON] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize equals" do
-    let(:test_string) { "=" }
-    let(:expected_tokens) { [Tokens::EQUALS] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize plus equals" do
-    let(:test_string) { "+=" }
-    let(:expected_tokens) { [Tokens::PLUS_EQUALS] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize comma, colon, plus equals, and equals together" do
-    let(:test_string) { "=:,+=" }
-    let(:expected_tokens) { [Tokens::EQUALS,
-                             Tokens::COLON,
-                             Tokens::COMMA,
-                             Tokens::PLUS_EQUALS] }
-
-    include_examples "token_matching"
-  end
-
 
   ####################
   # Substitutions
   ####################
-  context "tokenize substitution" do
-    let(:test_string) { "${a.b}" }
-    let(:expected_tokens) { [TestUtils.token_substitution([TestUtils.token_unquoted("a.b")])] }
+  context "tokenizing substitutions" do
+    context "tokenize substitution" do
+      let(:test_string) { "${a.b}" }
+      let(:expected_tokens) { [TestUtils.token_substitution(TestUtils.token_unquoted("a.b"))] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize optional substitution" do
-    let(:test_string) { "${?x.y}" }
-    let(:expected_tokens) { [TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y"))] }
+    context "tokenize optional substitution" do
+      let(:test_string) { "${?x.y}" }
+      let(:expected_tokens) { [TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y"))] }
 
-    include_examples "token_matching"
-  end
+      include_examples "token_matching"
+    end
 
-  context "tokenize key substitution" do
-    let(:test_string) { "${?x.y}" }
-    let(:expected_tokens) { [TestUtils.token_key_substitution(TestUtils.token_unquoted("x.y"))] }
+    context "tokenize key substitution" do
+      let(:test_string) { '${"c.d"}' }
+      let(:expected_tokens) { [TestUtils.token_key_substitution("c.d")] }
 
-    include_examples "token_matching"
-  end
-
-  ####################
-  # Unicode
-  ####################
-  context "tokenize unicode character" do
-    let(:test_string) { "\"\\u221E\"" }
-    let(:expected_tokens) { [TestUtils.token_string("\u{221E}")] }
-
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
   end
 
   ####################
-  # Escaped Strings
+  # Unicode and escape characters
   ####################
-  context "tokenize null byte" do
-    let(:test_string) { " \"\\u0000\" " }
-    let(:expected_tokens) { [TestUtils.token_string("\u0000")] }
+  context "tokenizing unicode and escape characters" do
+    context "tokenize unicode infinity symbol" do
+      let(:test_string) { '"\u221E"' }
+      let(:expected_tokens) { [TestUtils.token_string("\u{221E}")] }
 
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
+
+    context "tokenize null byte" do
+      let(:test_string) { ' "\u0000" ' }
+      let(:expected_tokens) { [TestUtils.token_string("\u0000")] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize various espace codes" do
+      let(:test_string) { ' "\"\\\/\b\f\n\r\t" ' }
+      let(:expected_tokens) { [TestUtils.token_string("\"\\/\b\f\n\r\t")] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize unicode F" do
+      let(:test_string) { '"\u0046"' }
+      let(:expected_tokens) { [TestUtils.token_string("F")] }
+
+      include_examples "token_matching"
+    end
+
+    context "tokenize two unicode Fs" do
+      let(:test_string) { '"\u0046\u0046"' }
+      let(:expected_tokens) { [TestUtils.token_string("FF")] }
+
+      include_examples "token_matching"
+    end
   end
 
-  context "tokenize various espace codes" do
-    let(:test_string) { " \"\\\"\\\\\\/\\b\\f\\n\\r\\t\"" }
-    let(:expected_tokens) { [TestUtils.token_string("\"\\/\b\f\n\r\t")] }
+  ####################
+  # Reserved Characters
+  ####################
+  context "Finding problems with using reserved characters" do
+    context "problem with reserved character +" do
+      let(:test_string) { "+" }
+      include_examples "strings_with_problems"
+    end
 
-    include_examples "token_matching"
-  end
+    context "problem with reserved character `" do
+      let(:test_string) { "`" }
+      include_examples "strings_with_problems"
+    end
 
-  context "tokenize unicode F" do
-    let(:test_string) { "\"\\u0046\"" }
-    let(:expected_tokens) { [TestUtils.token_string("F")] }
+    context "problem with reserved character ^" do
+      let(:test_string) { "^" }
+      include_examples "strings_with_problems"
+    end
 
-    include_examples "token_matching"
-  end
+    context "problem with reserved character ?" do
+      let(:test_string) { "?" }
+      include_examples "strings_with_problems"
+    end
 
-  context "tokenize two unicode Fs" do
-    let(:test_string) { "\"\\u0046\\u0046\"" }
-    let(:expected_tokens) { [TestUtils.token_string("FF")] }
+    context "problem with reserved character !" do
+      let(:test_string) { "!" }
+      include_examples "strings_with_problems"
+    end
 
-    include_examples "token_matching"
+    context "problem with reserved character @" do
+      let(:test_string) { "@" }
+      include_examples "strings_with_problems"
+    end
+
+    context "problem with reserved character *" do
+      let(:test_string) { "*" }
+      include_examples "strings_with_problems"
+    end
+
+    context "problem with reserved character &" do
+      let(:test_string) { "&" }
+      include_examples "strings_with_problems"
+    end
+
+    context "problem with reserved character \\" do
+      let(:test_string) { "\\" }
+      include_examples "strings_with_problems"
+    end
   end
 
   ####################
   # Combine all types
   ####################
-  context "problem with reserved character +" do
-    let(:test_string) { "+" }
-    include_examples "strings_with_problems"
-  end
+  context "Tokenizing all types together" do
+    context "tokenize all types no spaces" do
+      let(:test_string) { ',:=}{][+="foo""""bar"""true3.14false42null${a.b}${?x.y}${"c.d"}' + "\n" }
+      let(:expected_tokens) { [Tokens::COMMA,
+                               Tokens::COLON,
+                               Tokens::EQUALS,
+                               Tokens::CLOSE_CURLY,
+                               Tokens::OPEN_CURLY,
+                               Tokens::CLOSE_SQUARE,
+                               Tokens::OPEN_SQUARE,
+                               Tokens::PLUS_EQUALS,
+                               TestUtils.token_string("foo"),
+                               TestUtils.token_string("bar"),
+                               TestUtils.token_true,
+                               TestUtils.token_float(3.14),
+                               TestUtils.token_false,
+                               TestUtils.token_int(42),
+                               TestUtils.token_null,
+                               TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
+                               TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
+                               TestUtils.token_key_substitution("c.d"),
+                               TestUtils.token_line(1)] }
 
-  context "problem with reserved character `" do
-    let(:test_string) { "`" }
-    include_examples "strings_with_problems"
-  end
+      include_examples "token_matching"
+    end
 
-  context "problem with reserved character ^" do
-    let(:test_string) { "^" }
-    include_examples "strings_with_problems"
-  end
+    context "tokenize all types single spaces" do
+      let(:test_string) { ' , : = } { ] [ += "foo" """bar""" 42 true 3.14 false null ${a.b} ${?x.y} ${"c.d"} ' + "\n " }
+      let(:expected_tokens) { [Tokens::COMMA,
+                               Tokens::COLON,
+                               Tokens::EQUALS,
+                               Tokens::CLOSE_CURLY,
+                               Tokens::OPEN_CURLY,
+                               Tokens::CLOSE_SQUARE,
+                               Tokens::OPEN_SQUARE,
+                               Tokens::PLUS_EQUALS,
+                               TestUtils.token_string("foo"),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_string("bar"),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_int(42),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_true,
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_float(3.14),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_false,
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_null,
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
+                               TestUtils.token_unquoted(" "),
+                               TestUtils.token_key_substitution("c.d"),
+                               TestUtils.token_line(1)] }
 
-  context "problem with reserved character ?" do
-    let(:test_string) { "?" }
-    include_examples "strings_with_problems"
-  end
+      include_examples "token_matching"
+    end
 
-  context "problem with reserved character !" do
-    let(:test_string) { "!" }
-    include_examples "strings_with_problems"
-  end
+    context "tokenize all types multiple spaces" do
+      let(:test_string) { '   ,   :   =   }   {   ]   [   +=   "foo"   """bar"""   42   true   3.14   false   null   ${a.b}   ${?x.y}   ${"c.d"}   ' + "\n   " }
+      let(:expected_tokens) { [Tokens::COMMA,
+                               Tokens::COLON,
+                               Tokens::EQUALS,
+                               Tokens::CLOSE_CURLY,
+                               Tokens::OPEN_CURLY,
+                               Tokens::CLOSE_SQUARE,
+                               Tokens::OPEN_SQUARE,
+                               Tokens::PLUS_EQUALS,
+                               TestUtils.token_string("foo"),
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_string("bar"),
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_int(42),
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_true,
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_float(3.14),
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_false,
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_null,
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
+                               TestUtils.token_unquoted("   "),
+                               TestUtils.token_key_substitution("c.d"),
+                               TestUtils.token_line(1)] }
 
-  context "problem with reserved character @" do
-    let(:test_string) { "@" }
-    include_examples "strings_with_problems"
-  end
-
-  context "problem with reserved character *" do
-    let(:test_string) { "*" }
-    include_examples "strings_with_problems"
-  end
-
-  context "problem with reserved character &" do
-    let(:test_string) { "&" }
-    include_examples "strings_with_problems"
-  end
-
-  context "problem with reserved character \\" do
-    let(:test_string) { "\\" }
-    include_examples "strings_with_problems"
-  end
-
-  ####################
-  # Combine all types
-  ####################
-  context "tokenize all types no spaces" do
-    let(:test_string) { ",:=}{][+=\"foo\"\"\"\"bar\"\"\"true3.14false42null${a.b}${?x.y}${\"c.d\"}\n" }
-    let(:expected_tokens) { [Tokens::COMMA,
-                             Tokens::COLON,
-                             Tokens::EQUALS,
-                             Tokens::CLOSE_CURLY,
-                             Tokens::OPEN_CURLY,
-                             Tokens::CLOSE_SQUARE,
-                             Tokens::OPEN_SQUARE,
-                             Tokens::PLUS_EQUALS,
-                             TestUtils.token_string("foo"),
-                             TestUtils.token_string("bar"),
-                             TestUtils.token_true,
-                             TestUtils.token_float(3.14),
-                             TestUtils.token_false,
-                             TestUtils.token_int(42),
-                             TestUtils.token_null,
-                             TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
-                             TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
-                             TestUtils.token_key_substitution("c.d"),
-                             TestUtils.token_line(1)] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize all types single spaces" do
-    let(:test_string) { " , : = } { ] [ += \"foo\" \"\"\"bar\"\"\" 42 true 3.14 false null ${a.b} ${?x.y} ${\"c.d\"} \n " }
-    let(:expected_tokens) { [Tokens::COMMA,
-                             Tokens::COLON,
-                             Tokens::EQUALS,
-                             Tokens::CLOSE_CURLY,
-                             Tokens::OPEN_CURLY,
-                             Tokens::CLOSE_SQUARE,
-                             Tokens::OPEN_SQUARE,
-                             Tokens::PLUS_EQUALS,
-                             TestUtils.token_string("foo"),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_string("bar"),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_int(42),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_true,
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_float(3.14),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_false,
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_null,
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
-                             TestUtils.token_unquoted(" "),
-                             TestUtils.token_key_substitution("c.d"),
-                             TestUtils.token_line(1)] }
-
-    include_examples "token_matching"
-  end
-
-  context "tokenize all types multiple spaces" do
-    let(:test_string) { "   ,   :   =   }   {   ]   [   +=   \"foo\"   \"\"\"bar\"\"\"   42   true   3.14   false   null   ${a.b}   ${?x.y}   ${\"c.d\"}   \n   " }
-    let(:expected_tokens) { [Tokens::COMMA,
-                             Tokens::COLON,
-                             Tokens::EQUALS,
-                             Tokens::CLOSE_CURLY,
-                             Tokens::OPEN_CURLY,
-                             Tokens::CLOSE_SQUARE,
-                             Tokens::OPEN_SQUARE,
-                             Tokens::PLUS_EQUALS,
-                             TestUtils.token_string("foo"),
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_string("bar"),
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_int(42),
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_true,
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_float(3.14),
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_false,
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_null,
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_substitution(TestUtils.token_unquoted("a.b")),
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_optional_substitution(TestUtils.token_unquoted("x.y")),
-                             TestUtils.token_unquoted("   "),
-                             TestUtils.token_key_substitution("c.d"),
-                             TestUtils.token_line(1)] }
-
-    include_examples "token_matching"
+      include_examples "token_matching"
+    end
   end
 end


### PR DESCRIPTION
Ported all the java tests from the hocon library to ruby-hocon
Added a few more here and there

Implemented misc missing functions from the java library to get the tests passing

Fixed bug in tokenizer that ignored whitespace between tokens